### PR TITLE
Make the path to eslint bin configurable

### DIFF
--- a/eslint-fix.el
+++ b/eslint-fix.el
@@ -28,12 +28,20 @@
 
 ;;; Code:
 
-;;;###autoload
+(defgroup eslint-fix nil
+  "Fix ESLint errors automatically"
+  :group 'convenience
+  :prefix "eslint-fix")
+
+(defcustom eslint-fix-eslint-bin (executable-find "eslint")
+  "The path the ESLint executable"
+  :type 'string)
+
 (defun eslint-fix ()
   "Format the current file with ESLint."
   (interactive)
-  (if (executable-find "eslint")
-      (progn (call-process "eslint" nil "*ESLint Errors*" nil "--fix" buffer-file-name)
+  (if eslint-fix-eslint-bin
+      (progn (call-process eslint-fix-eslint-bin nil "*ESLint Errors*" nil "--fix" buffer-file-name)
              (revert-buffer t t t))
     (message "ESLint not found.")))
 


### PR DESCRIPTION
Another possible improvement is to allow the bin to be a function in addition to a string, so the user can chose a strategy (ej, go to the directory with the .gitconfig file and look into node_modules there, etc)