### PR TITLE
eslint --fix --quiet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # eslint-fix
-Fix current file using `ESLint --fix`
+Fix current file using `ESLint --fix --quiet`
 
 ## Usage
 `M-x eslint-fix`

--- a/eslint-fix.el
+++ b/eslint-fix.el
@@ -33,7 +33,7 @@
   "Format the current file with ESLint."
   (interactive)
   (if (executable-find "eslint")
-      (progn (call-process "eslint" nil "*ESLint Errors*" nil "--fix" buffer-file-name)
+      (progn (call-process "eslint" nil "*ESLint Errors*" nil "--fix" "--quiet" buffer-file-name)
              (revert-buffer t t t))
     (message "ESLint not found.")))
 


### PR DESCRIPTION
`eslint --fix` fixes errors and warnings, whereas `eslint --fix --quiet` only fixes errors.

see https://github.com/eslint/eslint/issues/7549#issuecomment-314036951