### PR TITLE
Allow customizing the ESLint executable and options

### DIFF
--- a/eslint-fix.el
+++ b/eslint-fix.el
@@ -30,14 +30,18 @@
 
 (defgroup eslint-fix nil
   "Fix JavaScript linting issues with ‘eslint-fix’."
+  :link '(function-link eslint-fix)
+  :tag "ESLint Fix"
   :group 'tools)
 
 (defcustom eslint-fix-executable "eslint"
   "The ESLint executable to use."
+  :tag "ESLint Executable"
   :type 'string)
 
 (defcustom eslint-fix-options nil
   "Additional options to pass to ESLint (e.g. “--quiet”)."
+  :tag "ESLint Options"
   :type '(repeat string))
 
 ;;;###autoload

--- a/eslint-fix.el
+++ b/eslint-fix.el
@@ -7,7 +7,7 @@
 ;; Author: Neri Marschik <marschik_neri@cyberagent.co.jp>
 ;; Version: 1.0
 ;; Package-Requires: ()
-;; Keywords: javascript, eslint, lint, formatting, style
+;; Keywords: tools, javascript, eslint, lint, formatting, style
 ;; URL: https://github.com/codesuki/eslint-fix
 
 ;;; Commentary:


### PR DESCRIPTION
Force the user to save the current buffer before running ESLint. Since
ESLint uses the saved file and the buffer will be reverted, this helps
prevent accidental data loss.
