### PR TITLE
Add minor-mode for automatical fix.

### DIFF
--- a/eslint-fix.el
+++ b/eslint-fix.el
@@ -63,6 +63,14 @@
     (apply #'call-process eslint nil "*ESLint Errors*" nil options)
     (revert-buffer t t t)))
 
+;;;###autoload
+(define-minor-mode eslint-fix-auto-mode
+  "Run `eslint-fix' after save."
+  :group 'eslint-fix
+  (if eslint-fix-auto-mode
+      (add-hook 'after-save-hook #'eslint-fix nil t)
+    (remove-hook 'after-save-hook #'eslint-fix t)))
+
 (provide 'eslint-fix)
 
 ;;; eslint-fix.el ends here


### PR DESCRIPTION
Hi! Thanks for your great package!

I added minor mode for automatic running of `eslint-fix`.
Then we can write like:
```emacs-lisp
(eval-after-load 'js-mode
	   '(add-hook 'js-mode-hook #'eslint-fix-auto-mode))

(eval-after-load 'js2-mode
	   '(add-hook 'js2-mode-hook #'eslint-fix-auto-mode))
```

Note: Actually, `eval-after-load` is not needed because `add-hook` can handle undefined hook. So writing just like this is also valid:
```emacs-lisp 
(add-hook 'js-mode-hook #'eslint-fix-auto-mode)
(add-hook 'js2-mode-hook #'eslint-fix-auto-mode)
```